### PR TITLE
Add function createLabelForMissingLabelDefinition to abstract Schema

### DIFF
--- a/code/internal/+openminds/+abstract/Schema.m
+++ b/code/internal/+openminds/+abstract/Schema.m
@@ -560,6 +560,11 @@ classdef Schema < handle & openminds.internal.extern.uiw.mixin.AssignPVPairs & .
             displayLabel = sprintf("%s", str);
         end
 
+        function str = createLabelForMissingLabelDefinition(obj)
+            classNames = split( class(obj), '.');
+            str = sprintf('<Unlabeled %s>', classNames{end});
+        end
+
         function annotation = getAnnotation(obj)
 
             import openminds.internal.utility.getSchemaDocLink


### PR DESCRIPTION
Add a method on the abstract Schema class to generate a custom display label pattern if no label is specified to type classes. Allows easy update of custom display labels without changing pipeline