### PR TITLE
Update: Use token when retrieving info via GitHub api

### DIFF
--- a/code/internal/+openminds/+internal/+utility/+git/getCurrentCommitID.m
+++ b/code/internal/+openminds/+internal/+utility/+git/getCurrentCommitID.m
@@ -22,6 +22,11 @@ function [commitID, commitDetails] = getCurrentCommitID(repositoryName, options)
     requestOpts = weboptions();
     requestOpts.HeaderFields = {'Accept', 'application/vnd.github.sha'};
 
+    token = getenv('GITHUB_TOKEN');
+    if ~isempty(token)
+        requestOpts.HeaderFields = [options.HeaderFields; {'Authorization', ['token ' token]}];
+    end
+
     data = webread(apiURL, requestOpts);
     commitID = char(data');
 

--- a/code/internal/+openminds/+internal/+utility/+git/getCurrentCommitID.m
+++ b/code/internal/+openminds/+internal/+utility/+git/getCurrentCommitID.m
@@ -24,7 +24,7 @@ function [commitID, commitDetails] = getCurrentCommitID(repositoryName, options)
 
     token = getenv('GITHUB_TOKEN');
     if ~isempty(token)
-        requestOpts.HeaderFields = [options.HeaderFields; {'Authorization', ['token ' token]}];
+        requestOpts.HeaderFields = [requestOpts.HeaderFields; {'Authorization', ['token ' token]}];
     end
 
     data = webread(apiURL, requestOpts);


### PR DESCRIPTION
Motivation: Prevent rate limit errors if running multiple requests in short order, as GitHub's public api premits only a few requests per hour