### PR TITLE
Update getSchemaName.m

### DIFF
--- a/code/internal/+openminds/+internal/+vocab/getSchemaName.m
+++ b/code/internal/+openminds/+internal/+vocab/getSchemaName.m
@@ -24,14 +24,12 @@ function schemaName = getSchemaName(nameAlias)
     end
 
     C = struct2cell(typesVocab);
-    S = [C{:}];
 
-    allNames = {S.name};
-
+    allNames = cellfun(@(c) string(c.name), C);
     isMatch = strcmpi(allNames, nameAlias);
     
     if ~any(isMatch)
-        allLabels = {S.label};
+        allLabels = cellfun(@(c) string(c.label), C);
         isMatch = strcmpi(allLabels, nameAlias);
     end
 


### PR DESCRIPTION
Remove concatenation of structs. Structs might have different fields, and the concatenation would fail. Only need name and potentially label, so explicitly get these instead of relying on struct concatenation