### PR TITLE
Fix: case-insensitive name matching and indexing for vocab metadata

### DIFF
--- a/code/internal/+openminds/+internal/+vocab/getSchemaColor.m
+++ b/code/internal/+openminds/+internal/+vocab/getSchemaColor.m
@@ -7,12 +7,12 @@ function color = getSchemaColor(schemaName)
     end
     
     C = struct2cell(typesVocab);
-    S = [C{:}];
 
-    isMatch = strcmp({S.name}, schemaName);
+    allNames = cellfun(@(c) string(c.name), C);
+    isMatch = strcmpi(allNames, schemaName);
 
     if any(isMatch)
-        color = S(isMatch).color;
+        color = C{isMatch}.color;
     else
         error('No schemas matched name "%s"', schemaName)
     end

--- a/code/internal/+openminds/+internal/+vocab/getSchemaLabelFromName.m
+++ b/code/internal/+openminds/+internal/+vocab/getSchemaLabelFromName.m
@@ -10,16 +10,15 @@ function schemaLabel = getSchemaLabelFromName(schemaName)
     end
 
     C = struct2cell(typesVocab);
-    S = [C{:}];
 
-    allNames = {S.name};
+    allNames = cellfun(@(c) string(c.name), C);
     isMatch = strcmpi(allNames, schemaName);
     
     if ~any(isMatch)
         throwNoMatchingSchemaException(schemaName);
     end
 
-    S = S(isMatch);
+    S = C{isMatch};
     schemaLabel = string( S(1).label );
 
     if isscalar(S)


### PR DESCRIPTION
Remove struct concatenation, not guaranteed that the types vocab is homogeneous