### PR TITLE
[Pipeline] Fix pipeline schema generation bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,12 @@ This branch contains the openMINDS pipeline for the openMINDS_MATLAB repository.
 
 This pipeline consists of the following workflows:
 - `build` : Build the MATLAB schema classes from openMINDS source schemas when these are updated.
+
+
+## Getting started
+
+```bash
+pip install -r requirements.txt
+```
+
+python build.py

--- a/build.py
+++ b/build.py
@@ -1,5 +1,6 @@
 import os.path
 import shutil
+import sys
 
 from pipeline.translator import MATLABSchemaBuilder
 from pipeline.utils import clone_sources, SchemaLoader, initialise_jinja_templates, save_resource_files, save_enumeration_classes, get_class_name_map
@@ -16,6 +17,7 @@ if os.path.exists("target"):
 
 # Step 2 - Initialise the jinja templates
 jinja_templates = initialise_jinja_templates()
+build_errors = []
 
 for schema_version in schema_loader.get_schema_versions():
 
@@ -37,6 +39,7 @@ for schema_version in schema_loader.get_schema_versions():
                 annotation_type = "warning"
             else:
                 annotation_type = "error"
+                build_errors.append((schema_version, schema_file_path, e))
 
             # get relative path from schema_root_path to schema_file_path
             relative_path = os.path.relpath(schema_file_path, schema_root_path)
@@ -48,3 +51,7 @@ for schema_version in schema_loader.get_schema_versions():
     
     save_enumeration_classes("Types", schema_version, schema_loader, jinja_templates["types_enumeration"])
     save_enumeration_classes("Modules", schema_version, schema_loader, jinja_templates["modules_enumeration"])
+
+if build_errors:
+    print(f"Build failed: {len(build_errors)} schema class(es) could not be generated.")
+    sys.exit(1)

--- a/pipeline/templates/controlledterm_class_template.txt
+++ b/pipeline/templates/controlledterm_class_template.txt
@@ -29,12 +29,27 @@ classdef {{ class_name }} < openminds.abstract.ControlledTerm
         {%- endfor %}
         ]
     end
+    {%- if additional_controlled_term_props %}
+
+    properties
+    {%- for prop in additional_controlled_term_props %}
+        % {{ prop.doc }}
+        {{ prop.name }} {{prop.size}} {{ prop.type }} {%- if prop.validators%} ...{% endif %}
+        {%- if prop.validators %}
+            {{prop.validators}}
+        {%- endif -%}
+    {%- if not loop.last -%}
+        {{ ' ' }}
+    {% endif %}
+    {%- endfor %}
+    end
+    {%- endif %}
 
     methods
         function obj = {{ class_name }}(instanceSpec, propValues)
             arguments
                 instanceSpec = []
-                propValues.?openminds.abstract.ControlledTerm
+                propValues.?{{ full_class_name }}
                 propValues.id (1,1) string
             end
 

--- a/pipeline/translator.py
+++ b/pipeline/translator.py
@@ -32,6 +32,21 @@ types_with_controlled_instances = [
     "ParcellationEntityVersion"
 ]
 
+controlled_term_base_properties = {
+    "definition",
+    "description",
+    "identifier",
+    "interlexIdentifier",
+    "knowledgeSpaceLink",
+    "name",
+    "ontologyIdentifier",
+    "otherCrossReference",
+    "otherOntologyIdentifier",
+    "preferredCrossReference",
+    "preferredOntologyIdentifier",
+    "synonym",
+}
+
 type_name_map = {
     "string": "string",
     "integer": "int64",
@@ -229,6 +244,11 @@ class MATLABSchemaBuilder(object):
         
         linked_types = [ {'name':prop["name"],'types':prop["type_list"]} for prop in props if prop["is_linked"] ]
         embedded_types = [ {'name':prop["name"],'types':prop["type_list"]} for prop in props if prop["is_embedded"] ]
+        additional_controlled_term_props = [
+            prop for prop in props
+            if self._schema_module_name == "controlledTerms"
+            and prop["name"] not in controlled_term_base_properties
+        ]
 
         # Some schemas had the wrong type in older model versions, so this is unreliable
         #class_name = _generate_class_name(schema[SCHEMA_PROPERTY_TYPE], self._class_name_map).split(".")[-1]
@@ -268,6 +288,7 @@ class MATLABSchemaBuilder(object):
             "required_properties": [f'{prop["name"]}' for prop in props if prop["required"]],
             "linked_types": linked_types,
             "embedded_types": embedded_types,
+            "additional_controlled_term_props": additional_controlled_term_props,
             "display_label_method_expression": display_label_method_expression,
             "known_instance_list": known_instance_list,
         }

--- a/pipeline/translator.py
+++ b/pipeline/translator.py
@@ -350,6 +350,9 @@ def _generate_class_name(iri, class_name_map):
     Generate a class name from an IRI. 
     E.g https://openminds.ebrains.eu/core/Subject -> openminds.core.Subject
     """
+    if iri in class_name_map:
+        return class_name_map[iri]
+
     if iri.startswith("https://"): # v3 and lower
         parts = iri.split("/")[-2:]
     else: # v4 and higher
@@ -361,7 +364,7 @@ def _generate_class_name(iri, class_name_map):
     type_name = type_name[0].upper() + type_name[1:]
 
     if type_name not in class_name_map:
-        raise KeyError(f"Class name '{type_name}' (IRI: {iri}) was not found in the map of all class names.")
+        raise KeyError(f"Class name for IRI '{iri}' was not found in the map of all class names.")
 
     return class_name_map[type_name]
 

--- a/pipeline/translator.py
+++ b/pipeline/translator.py
@@ -4,7 +4,6 @@ Generates openMINDS MATLAB classes.
 
 import glob
 import json
-import math
 import os
 import re
 from typing import List, Dict
@@ -518,7 +517,7 @@ def _create_property_validator_functions(name, property_info):
 
         if "date" in property_info.get("_formats"):
             validation_functions += [f"mustBeValidDate({property_name})"]
-        elif "time" in property_info.get("_formats") == "time":
+        elif "time" in property_info.get("_formats"):
             validation_functions += [f"mustBeValidTime({property_name})"]
 
     if isinstance( property_info.get("type"), list ):
@@ -550,18 +549,24 @@ def _create_property_validator_functions(name, property_info):
 
         validation_functions += [f"mustMatchPattern({name}, '{escaped_str_pattern}')"]
 
-    if 'minimum' in property_info or 'maximum' in property_info:
-        min_value = property_info.get('minimum', float('nan'))
-        max_value = property_info.get('maximum', float('nan'))
+    if any(key in property_info for key in ('minimum', 'maximum', 'exclusiveMinimum', 'exclusiveMaximum')):
+        if property_info.get("type") == "integer":
+            validation_functions += [f"mustBeInteger({name})"]
 
-        validation_functions += [f"mustBeInteger({name})"]
-
-        if not math.isnan(min_value) and not math.isnan(max_value):
+        if 'minimum' in property_info and 'maximum' in property_info:
+            min_value = property_info['minimum']
+            max_value = property_info['maximum']
             validation_functions += [f"mustBeInRange({name}, {min_value}, {max_value})"]
-        elif math.isnan(min_value):
-            validation_functions += [f"mustBeLessThanOrEqual({name}, {max_value})"]
-        elif math.isnan(max_value):
-            validation_functions += [f"mustBeGreaterThanOrEqual({name}, {min_value})"]
+        elif 'minimum' in property_info:
+            validation_functions += [f"mustBeGreaterThanOrEqual({name}, {property_info['minimum']})"]
+        elif 'maximum' in property_info:
+            validation_functions += [f"mustBeLessThanOrEqual({name}, {property_info['maximum']})"]
+
+        if 'exclusiveMinimum' in property_info:
+            validation_functions += [f"mustBeGreaterThan({name}, {property_info['exclusiveMinimum']})"]
+
+        if 'exclusiveMaximum' in property_info:
+            validation_functions += [f"mustBeLessThan({name}, {property_info['exclusiveMaximum']})"]
 
     return validation_functions
 

--- a/pipeline/translator.py
+++ b/pipeline/translator.py
@@ -7,7 +7,7 @@ import json
 import os
 import re
 from typing import List, Dict
-from collections import defaultdict
+from collections import Counter, defaultdict
 import warnings
 
 from jinja2 import Template
@@ -31,21 +31,6 @@ types_with_controlled_instances = [
     "ParcellationEntity",
     "ParcellationEntityVersion"
 ]
-
-controlled_term_base_properties = {
-    "definition",
-    "description",
-    "identifier",
-    "interlexIdentifier",
-    "knowledgeSpaceLink",
-    "name",
-    "ontologyIdentifier",
-    "otherCrossReference",
-    "otherOntologyIdentifier",
-    "preferredCrossReference",
-    "preferredOntologyIdentifier",
-    "synonym",
-}
 
 type_name_map = {
     "string": "string",
@@ -73,6 +58,7 @@ class MATLABSchemaBuilder(object):
 
     def __init__(self, schema_file_path:str, root_path:str, class_name_map:Dict[str, str], jinja_templates:Dict[str, Template]):
         
+        self._schema_root_path = root_path
         self._parse_source_file_path(schema_file_path, root_path)
         self._class_name_map = class_name_map
 
@@ -244,11 +230,17 @@ class MATLABSchemaBuilder(object):
         
         linked_types = [ {'name':prop["name"],'types':prop["type_list"]} for prop in props if prop["is_linked"] ]
         embedded_types = [ {'name':prop["name"],'types':prop["type_list"]} for prop in props if prop["is_embedded"] ]
-        additional_controlled_term_props = [
-            prop for prop in props
-            if self._schema_module_name == "controlledTerms"
-            and prop["name"] not in controlled_term_base_properties
-        ]
+        if self._schema_module_name == "controlledTerms":
+            controlled_term_base_properties = _get_controlled_term_base_properties(
+                self._schema_root_path,
+                self.version,
+            )
+            additional_controlled_term_props = [
+                prop for prop in props
+                if prop["name"] not in controlled_term_base_properties
+            ]
+        else:
+            additional_controlled_term_props = []
 
         # Some schemas had the wrong type in older model versions, so this is unreliable
         #class_name = _generate_class_name(schema[SCHEMA_PROPERTY_TYPE], self._class_name_map).split(".")[-1]
@@ -344,6 +336,31 @@ class MATLABSchemaBuilder(object):
 def _create_matlab_name(json_name):
     """Remove the openMINDS prefix from a name"""
     return json_name.split('/')[-1]
+
+
+def _get_controlled_term_base_properties(schema_root_path, version):
+    """Return the common controlled-term property set for a schema version."""
+    controlled_term_schema_paths = glob.glob(
+        os.path.join(schema_root_path, version, "controlledTerms", "*.schema.omi.json")
+    )
+
+    property_sets = Counter()
+
+    for schema_file_path in controlled_term_schema_paths:
+        with open(schema_file_path, "r", encoding="utf-8") as schema_file:
+            schema_payload = json.load(schema_file)
+
+        property_names = frozenset(
+            _create_matlab_name(property_name)
+            for property_name in schema_payload.get("properties", {})
+        )
+        property_sets[property_names] += 1
+
+    if not property_sets:
+        return set()
+
+    return set(property_sets.most_common(1)[0][0])
+
 
 def _generate_class_name(iri, class_name_map):
     """

--- a/pipeline/translator.py
+++ b/pipeline/translator.py
@@ -556,7 +556,7 @@ def _create_property_validator_functions(name, property_info):
         max_items = property_info.get('maxItems', 'inf')
         validation_functions += [f"mustBeSpecifiedLength({name}, {min_items}, {max_items})"]
 
-    if property_info.get('uniqueItems') is True or property_info.get('unqiueItems') is True:
+    if property_info.get('uniqueItems') is True:
         validation_functions += [f"mustBeListOfUniqueItems({name})"]
 
     if 'minLength' in property_info or 'maxLength' in property_info:

--- a/pipeline/translator.py
+++ b/pipeline/translator.py
@@ -595,9 +595,17 @@ def _create_property_validator_functions(name, property_info):
             validation_functions += [f'mustBeSpecifiedLength({property_name}, 0, 1)']
 
     if 'minItems' in property_info or 'maxItems' in property_info:
-        min_items = property_info.get('minItems', 0)
-        max_items = property_info.get('maxItems', 'inf')
-        validation_functions += [f"mustBeSpecifiedLength({name}, {min_items}, {max_items})"]
+        has_min_items = 'minItems' in property_info
+        has_max_items = 'maxItems' in property_info
+
+        if has_min_items and has_max_items:
+            min_items = property_info['minItems']
+            max_items = property_info['maxItems']
+            validation_functions += [f"mustBeSpecifiedLength({name}, {min_items}, {max_items})"]
+        elif has_min_items:
+            validation_functions += [f"mustBeMinLength({name}, {property_info['minItems']})"]
+        elif has_max_items:
+            validation_functions += [f"mustBeMaxLength({name}, {property_info['maxItems']})"]
 
     if property_info.get('uniqueItems') is True:
         validation_functions += [f"mustBeListOfUniqueItems({name})"]

--- a/pipeline/translator.py
+++ b/pipeline/translator.py
@@ -390,7 +390,7 @@ def _get_schema_display_label(schema_short_name):
         schema_name_label = schema_short_name
     else:
         #Replace each capital letter with a space and the capital letter
-        schema_name_label = re.sub("([A-Z])", " \g<0>", schema_short_name).strip().lower()
+        schema_name_label = re.sub("([A-Z])", r" \g<0>", schema_short_name).strip().lower()
 
     return schema_name_label
 

--- a/pipeline/translator.py
+++ b/pipeline/translator.py
@@ -577,10 +577,12 @@ def _create_property_validator_functions(name, property_info):
     validation_functions = []
 
     if property_info.get("type") == 'integer':
-        validation_functions += [f'mustBeSpecifiedLength({property_name}, 0, 1)']
+        validation_functions += [f'mustBeMinLength({property_name}, 0)']
+        validation_functions += [f'mustBeMaxLength({property_name}, 1)']
 
     if _is_datetime_format(property_info):
-        validation_functions += [f'mustBeSpecifiedLength({property_name}, 0, 1)']
+        validation_functions += [f'mustBeMinLength({property_name}, 0)']
+        validation_functions += [f'mustBeMaxLength({property_name}, 1)']
 
         if "date" in property_info.get("_formats"):
             validation_functions += [f"mustBeValidDate({property_name})"]
@@ -592,7 +594,8 @@ def _create_property_validator_functions(name, property_info):
 
     if has_linked_type or has_embedded_type:
         if not allow_multiple:
-            validation_functions += [f'mustBeSpecifiedLength({property_name}, 0, 1)']
+            validation_functions += [f'mustBeMinLength({property_name}, 0)']
+            validation_functions += [f'mustBeMaxLength({property_name}, 1)']
 
     if 'minItems' in property_info or 'maxItems' in property_info:
         has_min_items = 'minItems' in property_info
@@ -601,7 +604,8 @@ def _create_property_validator_functions(name, property_info):
         if has_min_items and has_max_items:
             min_items = property_info['minItems']
             max_items = property_info['maxItems']
-            validation_functions += [f"mustBeSpecifiedLength({name}, {min_items}, {max_items})"]
+            validation_functions += [f"mustBeMinLength({name}, {min_items})"]
+            validation_functions += [f"mustBeMaxLength({name}, {max_items})"]
         elif has_min_items:
             validation_functions += [f"mustBeMinLength({name}, {property_info['minItems']})"]
         elif has_max_items:

--- a/pipeline/translator.py
+++ b/pipeline/translator.py
@@ -528,27 +528,20 @@ def _create_property_validator_functions(name, property_info):
         if not allow_multiple:
             validation_functions += [f'mustBeSpecifiedLength({property_name}, 0, 1)']
 
-    if 'maxItems' in property_info:
-        if 'minItems' in property_info:
-            min_items = property_info['minItems']
-            # Uncomment the following lines if needed
-            # if 'required' in obj.Schema and name not in obj.Schema['required']:
-            #     min_items = 0
-        else:
-            min_items = 0
-
-        max_items = property_info['maxItems']
+    if 'minItems' in property_info or 'maxItems' in property_info:
+        min_items = property_info.get('minItems', 0)
+        max_items = property_info.get('maxItems', 'inf')
         validation_functions += [f"mustBeSpecifiedLength({name}, {min_items}, {max_items})"]
 
-    elif 'uniqueItems' in property_info:
+    if property_info.get('uniqueItems') is True or property_info.get('unqiueItems') is True:
         validation_functions += [f"mustBeListOfUniqueItems({name})"]
 
-    elif 'minLength' in property_info or 'maxLength' in property_info:
+    if 'minLength' in property_info or 'maxLength' in property_info:
         min_length = property_info.get('minLength', 0)
         max_length = property_info.get('maxLength', float('inf'))
         validation_functions += [f"mustBeValidStringLength({name}, {min_length}, {max_length})"]
 
-    elif 'pattern' in property_info:
+    if 'pattern' in property_info:
         if 'archive.softwareheritage' in property_info['pattern']:
             print("SWHID str pattern validation is hard-coded")
             escaped_str_pattern = r"^https://archive.softwareheritage.org/swh:1:(cnt|dir|rel|rev|snp):[0-9a-f]{40}(;(origin|visit|anchor|path|lines)=[^ \t\r\n\f]+)*$"
@@ -557,7 +550,7 @@ def _create_property_validator_functions(name, property_info):
 
         validation_functions += [f"mustMatchPattern({name}, '{escaped_str_pattern}')"]
 
-    elif 'minimum' in property_info or 'maximum' in property_info:
+    if 'minimum' in property_info or 'maximum' in property_info:
         min_value = property_info.get('minimum', float('nan'))
         max_value = property_info.get('maximum', float('nan'))
 

--- a/pipeline/translator.py
+++ b/pipeline/translator.py
@@ -577,12 +577,10 @@ def _create_property_validator_functions(name, property_info):
     validation_functions = []
 
     if property_info.get("type") == 'integer':
-        validation_functions += [f'mustBeMinLength({property_name}, 0)']
-        validation_functions += [f'mustBeMaxLength({property_name}, 1)']
+        validation_functions += [f'mustBeScalarOrEmpty({property_name})']
 
     if _is_datetime_format(property_info):
-        validation_functions += [f'mustBeMinLength({property_name}, 0)']
-        validation_functions += [f'mustBeMaxLength({property_name}, 1)']
+        validation_functions += [f'mustBeScalarOrEmpty({property_name})']
 
         if "date" in property_info.get("_formats"):
             validation_functions += [f"mustBeValidDate({property_name})"]
@@ -594,8 +592,7 @@ def _create_property_validator_functions(name, property_info):
 
     if has_linked_type or has_embedded_type:
         if not allow_multiple:
-            validation_functions += [f'mustBeMinLength({property_name}, 0)']
-            validation_functions += [f'mustBeMaxLength({property_name}, 1)']
+            validation_functions += [f'mustBeScalarOrEmpty({property_name})']
 
     if 'minItems' in property_info or 'maxItems' in property_info:
         has_min_items = 'minItems' in property_info

--- a/pipeline/utils.py
+++ b/pipeline/utils.py
@@ -143,12 +143,20 @@ def get_class_name_map(schema_loader, version):
 
     for schema_file in schema_files:
         schema_info = _parse_source_file_path(schema_file, root_path)
-        class_name_map[schema_info['type_name']] = _get_matlab_class_name(schema_info)
+        matlab_class_name = _get_matlab_class_name(schema_info)
+
+        with open(schema_file, "r", encoding="utf-8") as file:
+            schema_payload = json.load(file)
+
+        if "_type" in schema_payload:
+            class_name_map[schema_payload["_type"]] = matlab_class_name
+
+        class_name_map.setdefault(schema_info['type_name'], matlab_class_name)
 
     # Add some exceptions
     if version == "v2.0":
-        print(class_name_map["CustomAnatomicalEntity"])
         class_name_map["AnatomicalEntity"] = class_name_map["CustomAnatomicalEntity"]
+        class_name_map["https://openminds.ebrains.eu/sands/AnatomicalEntity"] = class_name_map["CustomAnatomicalEntity"]
 
 
     return class_name_map
@@ -322,4 +330,3 @@ def _get_template_variables(enum_type, schema_files, root_path):
     
 def _strip_trailing_whitespace(s):
     return "\n".join([line.rstrip() for line in s.splitlines()]) + "\n" # Also add single newline at the end
-


### PR DESCRIPTION
## Summary

This PR fixes several schema-generation issues in the Python pipeline:

- fail the build when non-v1 schema generation errors occur, instead of only printing GitHub annotations
- preserve independent property validators, so minItems, maxItems, and uniqueItems constraints do not mask each other
- stop generating the misleading mustBeSpecifiedLength validator
- generate mustBeScalarOrEmpty for scalar-or-empty properties, including required scalar properties whose requiredness is validated elsewhere
- generate mustBeMinLength and mustBeMaxLength for array cardinality constraints, including one-sided and closed minItems/maxItems bounds
- validate time-only formats and exclusive numeric bounds
- generate controlled-term extension properties and derive version-specific default controlled-term fields from the schemas
- resolve MATLAB class names by exact schema _type where possible, avoiding ambiguous short-name lookup
- escape display-label regex replacements correctly

## Verification

- python3 -m compileall -q build.py pipeline
- focused translator assertions for validator generation, controlled-term extension properties, exact _type lookup, and display-label formatting
- python3 build.py, generation only; no validation/tests run
