### PR TITLE
[CI] Update pinned action versions

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -36,19 +36,19 @@ jobs:
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE, so the job can access it
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
       
       - name: Set up MATLAB
-        uses: matlab-actions/setup-matlab@v2
+        uses: matlab-actions/setup-matlab@v3
         with:
           release: ${{ matrix.MATLABVersion }}
 
       # Check for MATLAB code issues in the project.
       - name: Check for MATLAB code issues
         if: matrix.MATLABVersion == env.LatestMATLABVersion
-        uses: matlab-actions/run-command@v2
+        uses: matlab-actions/run-command@v3
         with:
           command: addpath(genpath("tools")); codecheckToolbox()
     
@@ -63,7 +63,7 @@ jobs:
       # Run all tests in the project.
       - name: Run tests
         if: always()
-        uses: matlab-actions/run-command@v2
+        uses: matlab-actions/run-command@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -90,7 +90,7 @@ jobs:
 
       - name: Upload code coverage report to Codecov (https://app.codecov.io/gh/openMetadataInitiative/openMINDS_MATLAB)
         if: matrix.MATLABVersion == env.LatestMATLABVersion
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: docs/reports/codecoverage.xml
@@ -105,7 +105,7 @@ jobs:
           
       # Save the contents of the reports directory as an artifact
       - name: Save reports directory
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: reports-${{ matrix.MATLABVersion }}


### PR DESCRIPTION
## Summary

Updates GitHub Actions version pins in the test workflow.

Changed actions used by this repository:
- `actions/checkout` to `v6`
- `matlab-actions/setup-matlab` to `v3`
- `matlab-actions/run-command` to `v3`
- `codecov/codecov-action` to `v6`
- `actions/upload-artifact` to `v7`
