### PR TITLE
[codex] Regenerate display labels after generator fix

### DIFF
--- a/code/types/latest/+openminds/+core/+actors/Affiliation.m
+++ b/code/types/latest/+openminds/+core/+actors/Affiliation.m
@@ -52,7 +52,7 @@ classdef Affiliation < openminds.abstract.Schema
 
     methods (Access = protected)
         function str = getDisplayLabel(obj)
-            str = sprintf('%s', obj.memberOf);
+            str = obj.createLabelForMissingLabelDefinition();
         end
     end
 end

--- a/code/types/latest/+openminds/+core/+actors/Organization.m
+++ b/code/types/latest/+openminds/+core/+actors/Organization.m
@@ -117,7 +117,7 @@ classdef Organization < openminds.abstract.Schema
 
     methods (Access = protected)
         function str = getDisplayLabel(obj)
-            str = sprintf('%s', obj.fullName);
+            str = obj.name;
         end
     end
 end

--- a/code/types/latest/+openminds/+sands/+mathematicalshape/Ellipse.m
+++ b/code/types/latest/+openminds/+sands/+mathematicalshape/Ellipse.m
@@ -44,7 +44,7 @@ classdef Ellipse < openminds.abstract.Schema
 
     methods (Access = protected)
         function str = getDisplayLabel(obj)
-            str = sprintf('ellipse(r1=%s, r2=%s)', obj.semiMajorAxis, obj.semiMinorAxis);
+            str = obj.createLabelForMissingLabelDefinition();
         end
     end
 end

--- a/code/types/latest/+openminds/+sands/+mathematicalshape/Rectangle.m
+++ b/code/types/latest/+openminds/+sands/+mathematicalshape/Rectangle.m
@@ -52,7 +52,7 @@ classdef Rectangle < openminds.abstract.Schema
 
     methods (Access = protected)
         function str = getDisplayLabel(obj)
-            str = sprintf('rectangle(L=%s, W=%s)', obj.length, obj.width);
+            str = obj.createLabelForMissingLabelDefinition();
         end
     end
 end

--- a/code/types/v1.0/+openminds/+core/+actors/Affiliation.m
+++ b/code/types/v1.0/+openminds/+core/+actors/Affiliation.m
@@ -58,7 +58,7 @@ classdef Affiliation < openminds.abstract.Schema
 
     methods (Access = protected)
         function str = getDisplayLabel(obj)
-            str = sprintf('%s', obj.memberOf);
+            str = obj.createLabelForMissingLabelDefinition();
         end
     end
 end

--- a/code/types/v1.0/+openminds/+core/+actors/Contribution.m
+++ b/code/types/v1.0/+openminds/+core/+actors/Contribution.m
@@ -52,7 +52,7 @@ classdef Contribution < openminds.abstract.Schema
 
     methods (Access = protected)
         function str = getDisplayLabel(obj)
-            str = sprintf('%s (%s)', obj.contributor, obj.type);
+            str = obj.createLabelForMissingLabelDefinition();
         end
     end
 end

--- a/code/types/v2.0/+openminds/+core/+actors/Affiliation.m
+++ b/code/types/v2.0/+openminds/+core/+actors/Affiliation.m
@@ -58,7 +58,7 @@ classdef Affiliation < openminds.abstract.Schema
 
     methods (Access = protected)
         function str = getDisplayLabel(obj)
-            str = sprintf('%s', obj.memberOf);
+            str = obj.createLabelForMissingLabelDefinition();
         end
     end
 end

--- a/code/types/v2.0/+openminds/+core/+actors/Contribution.m
+++ b/code/types/v2.0/+openminds/+core/+actors/Contribution.m
@@ -52,7 +52,7 @@ classdef Contribution < openminds.abstract.Schema
 
     methods (Access = protected)
         function str = getDisplayLabel(obj)
-            str = sprintf('%s (%s)', obj.contributor, obj.type);
+            str = obj.createLabelForMissingLabelDefinition();
         end
     end
 end

--- a/code/types/v5.0/+openminds/+core/+actors/Affiliation.m
+++ b/code/types/v5.0/+openminds/+core/+actors/Affiliation.m
@@ -52,7 +52,7 @@ classdef Affiliation < openminds.abstract.Schema
 
     methods (Access = protected)
         function str = getDisplayLabel(obj)
-            str = sprintf('%s', obj.memberOf);
+            str = obj.createLabelForMissingLabelDefinition();
         end
     end
 end

--- a/code/types/v5.0/+openminds/+core/+actors/Organization.m
+++ b/code/types/v5.0/+openminds/+core/+actors/Organization.m
@@ -117,7 +117,7 @@ classdef Organization < openminds.abstract.Schema
 
     methods (Access = protected)
         function str = getDisplayLabel(obj)
-            str = sprintf('%s', obj.fullName);
+            str = obj.name;
         end
     end
 end

--- a/code/types/v5.0/+openminds/+sands/+mathematicalshape/Ellipse.m
+++ b/code/types/v5.0/+openminds/+sands/+mathematicalshape/Ellipse.m
@@ -44,7 +44,7 @@ classdef Ellipse < openminds.abstract.Schema
 
     methods (Access = protected)
         function str = getDisplayLabel(obj)
-            str = sprintf('ellipse(r1=%s, r2=%s)', obj.semiMajorAxis, obj.semiMinorAxis);
+            str = obj.createLabelForMissingLabelDefinition();
         end
     end
 end

--- a/code/types/v5.0/+openminds/+sands/+mathematicalshape/Rectangle.m
+++ b/code/types/v5.0/+openminds/+sands/+mathematicalshape/Rectangle.m
@@ -52,7 +52,7 @@ classdef Rectangle < openminds.abstract.Schema
 
     methods (Access = protected)
         function str = getDisplayLabel(obj)
-            str = sprintf('rectangle(L=%s, W=%s)', obj.length, obj.width);
+            str = obj.createLabelForMissingLabelDefinition();
         end
     end
 end


### PR DESCRIPTION
## Summary

Regenerates affected schema type classes after fixing display label generation on the `pipeline` branch.

## Root Cause

The generated getDisplayLabel methods had stale label implementations for some schema versions. In particular, v5/latest Organization still referenced `fullName`, although the v5 schema uses `name`.

## Changes

- Updates regenerated display labels for affected v1, v2, v5, and latest type classes.
