### PR TITLE
fix: update metatype tests for v5

### DIFF
--- a/code/internal/+openminds/+internal/+meta/Type.m
+++ b/code/internal/+openminds/+internal/+meta/Type.m
@@ -89,7 +89,7 @@ classdef Type < handle
                     obj.isPropertyWithEmbeddedType(propertyName)
                 validationFcn = mp.Validation.ValidatorFunctions;
                 
-                isScalar = @(str) contains(str, 'mustBeSpecifiedLength') && contains(str, '0,1)');
+                isScalar = @(str) contains(str, 'mustBeScalarOrEmpty');
                 tf = any( cellfun(@(c) isScalar(func2str(c)), validationFcn) );
             else
                 if isa( mp.Validation.Size(2), 'meta.UnrestrictedDimension')

--- a/tools/tests/+ommtest/+internal/MetaTypeTest.m
+++ b/tools/tests/+ommtest/+internal/MetaTypeTest.m
@@ -65,13 +65,14 @@ classdef MetaTypeTest < matlab.unittest.TestCase
         end
 
         function testMetaType(testCase)
-            % The following verifications was written for v4.0 of the
-            % DatasetVersion schema and might need to change in the future
+            previousVersion = openminds.version();
+            openminds.version(5);
+            testCase.addTeardown(@() openminds.version(previousVersion))
             
             metaDSV = openminds.internal.meta.fromClassName('DatasetVersion');
 
             testCase.verifyTrue( metaDSV.isPropertyValueScalar('accessibility') )
-            testCase.verifyFalse( metaDSV.isPropertyValueScalar('author') )
+            testCase.verifyFalse( metaDSV.isPropertyValueScalar('contribution') )
             
             testCase.verifyTrue( metaDSV.isPropertyWithLinkedType('accessibility') )
             testCase.verifyFalse( metaDSV.isPropertyWithLinkedType('description') )
@@ -80,21 +81,33 @@ classdef MetaTypeTest < matlab.unittest.TestCase
             testCase.verifyFalse( metaDSV.isPropertyWithEmbeddedType('accessibility') )
             testCase.verifyFalse( metaDSV.isPropertyWithEmbeddedType('description') )
             testCase.verifyTrue( metaDSV.isPropertyWithEmbeddedType('copyright') )
+            testCase.verifyTrue( metaDSV.isPropertyWithEmbeddedType('contribution') )
 
-            testCase.verifyTrue( metaDSV.isPropertyMixedType('author') )
+            testCase.verifyTrue( metaDSV.isPropertyMixedType('digitalIdentifier') )
+            testCase.verifyTrue( metaDSV.isPropertyMixedType('usageCondition') )
             testCase.verifyFalse( metaDSV.isPropertyMixedType('accessibility') )
+            testCase.verifyFalse( metaDSV.isPropertyMixedType('contribution') )
 
-            testCase.verifyTrue( metaDSV.isLinkedTypeOfAnyProperty("Person") )
-            testCase.verifyFalse( metaDSV.isLinkedTypeOfAnyProperty("SubjectState") )
+            testCase.verifyTrue( metaDSV.isLinkedTypeOfAnyProperty("SubjectState") )
+            testCase.verifyFalse( metaDSV.isLinkedTypeOfAnyProperty("Person") )
 
-            linkedAuthorTypes = metaDSV.listLinkedTypesForProperty('author');
-            testCase.verifyEqual(linkedAuthorTypes, ...
-                ["openminds.core.actors.Consortium", ...
-                "openminds.core.actors.Organization", ...
-                "openminds.core.actors.Person"])
+            linkedDigitalIdentifierTypes = metaDSV.listLinkedTypesForProperty('digitalIdentifier');
+            testCase.verifyEqual(linkedDigitalIdentifierTypes, ...
+                ["openminds.core.digitalidentifier.DOI", ...
+                "openminds.core.digitalidentifier.GenericIdentifier", ...
+                "openminds.core.digitalidentifier.IdentifiersDotOrgID", ...
+                "openminds.core.digitalidentifier.RRID"])
+
+            linkedUsageConditionTypes = metaDSV.listLinkedTypesForProperty('usageCondition');
+            testCase.verifyEqual(linkedUsageConditionTypes, ...
+                ["openminds.core.data.License", ...
+                "openminds.core.data.UsageAgreement"])
 
             embeddedCopyrightTypes = metaDSV.listEmbeddedTypesForProperty('copyright');
-            testCase.verifyEqual(embeddedCopyrightTypes, embeddedCopyrightTypes)
+            testCase.verifyEqual(embeddedCopyrightTypes, "openminds.core.data.Copyright")
+
+            embeddedContributionTypes = metaDSV.listEmbeddedTypesForProperty('contribution');
+            testCase.verifyEqual(embeddedContributionTypes, "openminds.core.actors.Contribution")
         end
     end
 end

--- a/tools/tests/unitTests/PropertyValidatorTest.m
+++ b/tools/tests/unitTests/PropertyValidatorTest.m
@@ -83,25 +83,24 @@ classdef PropertyValidatorTest < matlab.unittest.TestCase
                 'OPENMINDS_MATLAB:PropertyValidators:MustBeTypeOf')
         end
 
-        function testMustBeSpecifiedLength(testCase)
+        function testMustBeMinAndMaxLength(testCase)
             testValue = 1:5;
-            
-            % Test function when value exactly matches the required length
-            mustBeSpecifiedLength(testValue, 1, 5)
-            
-            % Test function when value is inside the required length
-            % interval
-            mustBeSpecifiedLength(testValue, 0, 6)
 
-            % Test function when value is too long
-            testCase.verifyError(...
-                @() mustBeSpecifiedLength(testValue, 1, 4), ...
-                'OPENMINDS_MATLAB:PropertyValidators:ListIsTooLong')
+            mustBeMinLength(testValue, 5)
+            mustBeMinLength(testValue, 4)
+            mustBeMinLength([], 1)
 
-            % Test function when value is too long
             testCase.verifyError(...
-                @() mustBeSpecifiedLength(testValue, 10, 15), ...
+                @() mustBeMinLength(testValue, 6), ...
                 'OPENMINDS_MATLAB:PropertyValidators:ListIsTooShort')
+
+            mustBeMaxLength(testValue, 5)
+            mustBeMaxLength(testValue, 6)
+            mustBeMaxLength([], 1)
+
+            testCase.verifyError(...
+                @() mustBeMaxLength(testValue, 4), ...
+                'OPENMINDS_MATLAB:PropertyValidators:ListIsTooLong')
         end
 
         function testMustBeValidEmail(testCase)


### PR DESCRIPTION
## Summary

- Update `MetaTypeTest/testMetaType` to exercise openMINDS v5 `DatasetVersion` properties and type mappings.
- Replace the removed `mustBeSpecifiedLength` validator test with coverage for `mustBeMinLength` and `mustBeMaxLength`.
- Simplify scalar property detection to use the current `mustBeScalarOrEmpty` validator.

## Root Cause

The test still asserted v4 `DatasetVersion` properties such as `author`, while v5 uses `contribution` and mixed linked properties such as `digitalIdentifier` and `usageCondition`. The scalar-detection helper also still looked for the removed `mustBeSpecifiedLength` validator.

## Validation

```Matlab
runtests('ommtest.internal.MetaTypeTest')
runtests('PropertyValidatorTest')

```